### PR TITLE
Make Sure FA Icons Are Visible

### DIFF
--- a/theme/components/navbar.vue
+++ b/theme/components/navbar.vue
@@ -6,10 +6,10 @@
         </b-navbar-nav>
         <b-navbar-nav class="ml-auto">
             <b-nav-item href="https://github.com/PieceMaker">
-                <fa :icon="[ 'fab', 'github' ]"></fa>
+                <fa class="social" :icon="[ 'fab', 'github' ]"></fa>
             </b-nav-item>
             <b-nav-item href="https://twitter.com/RebelActuary">
-                <fa :icon="[ 'fab', 'twitter' ]"></fa>
+                <fa class="social" :icon="[ 'fab', 'twitter' ]"></fa>
             </b-nav-item>
         </b-navbar-nav>
     </b-navbar>
@@ -22,5 +22,8 @@
 </script>
 
 <style scoped>
-
+    .social {
+        height: 1em;
+        width: 1em;
+    }
 </style>


### PR DESCRIPTION
This change adds a custom style to the FA icons to ensure they are visible whenever we do a production build of saber.